### PR TITLE
Tasks/order by

### DIFF
--- a/app/Http/Controllers/V1/CategorieController.php
+++ b/app/Http/Controllers/V1/CategorieController.php
@@ -9,7 +9,7 @@ use App\Http\Resources\V1\CategorieCollection;
 use App\Http\Requests\V1\StoreCategorieRequest;
 use App\Http\Requests\V1\UpdateCategorieRequest;
 use Illuminate\Http\Request;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class CategorieController extends Controller
 {
@@ -38,7 +38,7 @@ class CategorieController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
         $categories = Categorie::where($eloquentQuery)->paginate($perPage);
 
@@ -91,10 +91,10 @@ class CategorieController extends Controller
      * @param  \App\Models\Categorie  $categorie
      * @return \Illuminate\Http\Response
      */
-    public function update(UpdateCategorieRequest $request, Categorie $categorie)
-    {
-        //
-    }
+    // public function update(UpdateCategorieRequest $request, Categorie $categorie)
+    // {
+    //     
+    // }
 
     /**
      * Remove the specified resource from storage.

--- a/app/Http/Controllers/V1/CommentaireController.php
+++ b/app/Http/Controllers/V1/CommentaireController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\CommentaireResource;
 use App\Http\Resources\V1\CommentaireCollection;
 use App\Http\Requests\V1\StoreCommentaireRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class CommentaireController extends Controller
 {
@@ -55,23 +55,14 @@ class CommentaireController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
 
-        $typeOrder = 'asc';
-        $fieldOrder = 'id_commentaire';
-
-        $orderBy = $request->query('orderBy');
-        if($orderBy) {
-            $orderByArray = explode(',', $orderBy);
-            if (count($orderByArray) == 2) {
-                $fieldOrder = $orderByArray[0];
-                $typeOrder = $orderByArray[1];
-            }
-        }
-
+        // Order by
+        [$fieldOrder, $typeOrder] = (new QueryService)->translateOrderBy($request->query('orderBy'), 'id_commentaire', $this->columnMap); 
         $commentaires = Commentaire::where($eloquentQuery)->orderBy($fieldOrder, $typeOrder);
-
+     
+        //Todo Refactor this
         $includes = $request->query('include');
         if ($includes) {
             $includedArray = explode(',', $includes);

--- a/app/Http/Controllers/V1/FavorisController.php
+++ b/app/Http/Controllers/V1/FavorisController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\V1\StoreFavorisRequest;
 use App\Http\Resources\V1\FavorisResource;
 use App\Http\Resources\V1\FavorisCollection;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class FavorisController extends Controller
 {
@@ -49,10 +49,15 @@ class FavorisController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
         $favoris = Favoris::where($eloquentQuery);
 
+        // Order by
+        [$fieldOrder, $typeOrder] = (new QueryService)->translateOrderBy($request->query('orderBy'), 'id_favoris', $this->columnMap); 
+        $favoris = Favoris::where($eloquentQuery)->orderBy($fieldOrder, $typeOrder);
+
+        //apply includes (refactor this)
         $includes = $request->query('include');
         if ($includes) {
             $includedArray = explode(',', $includes);

--- a/app/Http/Controllers/V1/GroupeController.php
+++ b/app/Http/Controllers/V1/GroupeController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\GroupeResource;
 use App\Http\Resources\V1\GroupeCollection;
 use App\Http\Requests\V1\StoreGroupeRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class GroupeController extends Controller
 {
@@ -39,11 +39,14 @@ class GroupeController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
-        $groupe = Groupe::where($eloquentQuery)->paginate($perPage);    
 
-        return new GroupeCollection($groupe->appends($request->query()));
+        // Order by
+        [$fieldOrder, $typeOrder] = (new QueryService)->translateOrderBy($request->query('orderBy'), 'id_groupe', $this->columnMap); 
+        $groupe = Groupe::where($eloquentQuery)->orderBy($fieldOrder, $typeOrder);
+
+        return new GroupeCollection($groupe->paginate($perPage)->appends($request->query()));
     }
 
     /**

--- a/app/Http/Controllers/V1/PieceJointeController.php
+++ b/app/Http/Controllers/V1/PieceJointeController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\PieceJointeResource;
 use App\Http\Resources\V1\PieceJointeCollection;
 use App\Http\Requests\V1\StorePieceJointeRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class PieceJointeController extends Controller
 {
@@ -58,9 +58,12 @@ class PieceJointeController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
-        $piecesJointes = PieceJointe::where($eloquentQuery);
+        
+        // Order by
+        [$fieldOrder, $typeOrder] = (new QueryService)->translateOrderBy($request->query('orderBy'), 'id_piece_jointe', $this->columnMap); 
+        $piecesJointes = PieceJointe::where($eloquentQuery)->orderBy($fieldOrder, $typeOrder);
 
         $includes = $request->query('include');
         if ($includes) {

--- a/app/Http/Controllers/V1/RelationController.php
+++ b/app/Http/Controllers/V1/RelationController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\RelationResource;
 use App\Http\Resources\V1\RelationCollection;
 use App\Http\Requests\V1\StoreRelationRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class RelationController extends Controller
 {
@@ -52,11 +52,14 @@ class RelationController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
-        $relations = Relation::where($eloquentQuery)->paginate($perPage);
+
+        // Order by
+        [$fieldOrder, $typeOrder] = (new QueryService)->translateOrderBy($request->query('orderBy'), 'id_relation', $this->columnMap); 
+        $relations = Relation::where($eloquentQuery)->orderBy($fieldOrder, $typeOrder); 
         
-        return new RelationCollection($relations->appends($request->query()));
+        return new RelationCollection($relations->paginate($perPage)->appends($request->query()));
     }
 
     /**

--- a/app/Http/Controllers/V1/ReponseCommentaireController.php
+++ b/app/Http/Controllers/V1/ReponseCommentaireController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\ReponseCommentaireResource;
 use App\Http\Resources\V1\ReponseCommentaireCollection;
 use App\Http\Requests\V1\StoreReponseCommentaireRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class ReponseCommentaireController extends Controller
 {
@@ -53,9 +53,12 @@ class ReponseCommentaireController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
-        $reponsesCommentaires = ReponseCommentaire::where($eloquentQuery);
+        
+        // Order by
+        [$fieldOrder, $typeOrder] = (new QueryService)->translateOrderBy($request->query('orderBy'), 'id_reponse', $this->columnMap); 
+        $reponsesCommentaires = ReponseCommentaire::where($eloquentQuery)->orderBy($fieldOrder, $typeOrder); 
 
         $includes = $request->query('include');
         if ($includes) {

--- a/app/Http/Controllers/V1/RessourceController.php
+++ b/app/Http/Controllers/V1/RessourceController.php
@@ -9,7 +9,7 @@ use App\Http\Requests\V1\RefuseRessourceRequest;
 use App\Http\Resources\V1\RessourceResource;
 use App\Http\Resources\V1\RessourceCollection;
 use App\Http\Requests\V1\StoreRessourceRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class RessourceController extends Controller
 {
@@ -59,10 +59,13 @@ class RessourceController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
-        $ressources = Ressource::where($eloquentQuery);   
         
+        // Order by
+        [$fieldOrder, $typeOrder] = (new QueryService)->translateOrderBy($request->query('orderBy'), 'id_ressource', $this->columnMap); 
+        $ressources = Ressource::where($eloquentQuery)->orderBy($fieldOrder, $typeOrder); 
+
         $includes = $request->query('include');
         if ($includes) {
             $includedRessources = explode(',', $includes);

--- a/app/Http/Controllers/V1/RoleController.php
+++ b/app/Http/Controllers/V1/RoleController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\RoleResource;
 use App\Http\Resources\V1\RoleCollection;
 use App\Http\Requests\V1\StoreRoleRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 class RoleController extends Controller
 {
@@ -35,11 +35,11 @@ class RoleController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
-        $roles = Role::where($eloquentQuery)->paginate($perPage);
+        $roles = Role::where($eloquentQuery); 
 
-        return new RoleCollection($roles->appends($request->query()));
+        return new RoleCollection($roles->paginate($perPage)->appends($request->query()));
     }
 
     /**

--- a/app/Http/Controllers/V1/TypeRelationController.php
+++ b/app/Http/Controllers/V1/TypeRelationController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\TypeRelationResource;
 use App\Http\Resources\V1\TypeRelationCollection;
 use App\Http\Requests\V1\StoreTypeRelationRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 
 /**
  * @OA\Info(title="Search API", version="1.0.0")
@@ -42,11 +42,11 @@ class TypeRelationController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $filter = new QueryFilter();
+        $filter = new QueryService();
         $eloquentQuery = $filter->transform($queryContent, $this->allowedParams, $this->columnMap);
-        $typesRelations = TypeRelation::where($eloquentQuery)->paginate($perPage);
-
-        return new TypeRelationCollection($typesRelations->appends($request->query()));
+        $typesRelations = TypeRelation::where($eloquentQuery); 
+        
+        return new TypeRelationCollection($typesRelations->paginate($perPage)->appends($request->query()));
     }
 
     /**

--- a/app/Http/Controllers/V1/UtilisateurController.php
+++ b/app/Http/Controllers/V1/UtilisateurController.php
@@ -9,7 +9,7 @@ use App\Http\Resources\V1\UtilisateurResource;
 use App\Http\Resources\V1\UtilisateurCollection;
 use App\Http\Requests\V1\StoreUtilisateurRequest;
 use App\Http\Requests\V1\BanUtilisateurRequest;
-use App\Services\V1\QueryFilter;
+use App\Services\V1\QueryService;
 use App\Services\V1\TokenAttributor;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
@@ -63,8 +63,11 @@ class UtilisateurController extends Controller
     {
         $perPage = request()->input('perPage', 15);
         $queryContent = $request->all();
-        $eloquentQuery = (new QueryFilter)->transform($queryContent, $this->allowedParams, $this->columnMap);
-        $utilisateurs = Utilisateur::where($eloquentQuery);
+        $eloquentQuery = (new QueryService)->transform($queryContent, $this->allowedParams, $this->columnMap);
+        
+        // Order by
+        [$fieldOrder, $typeOrder] = (new QueryService)->translateOrderBy($request->query('orderBy'), 'id_uti', $this->columnMap); 
+        $utilisateurs = Utilisateur::where($eloquentQuery)->orderBy($fieldOrder, $typeOrder); 
 
         $includes = $request->query('include');
         if ($includes) {

--- a/app/Services/V1/QueryService.php
+++ b/app/Services/V1/QueryService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\V1;
 
-class QueryFilter
+class QueryService
 {
     /**
      * Allowed operators for filtering
@@ -26,27 +26,62 @@ class QueryFilter
     public function transform($request, $allowedParams, $columnMap)
     {
         $eloquentQuery = [];
-        
+
         foreach ($request as $param => $operators) {
             if (isset($allowedParams[$param])) {
                 foreach ($operators as $operator => $value) {
                     if (in_array($operator, $allowedParams[$param])) {
                         $columnName = $columnMap[$param];
                         $comparisonOperator = $this->operatorMap[$operator];
-                        $eloquentQuery[] = [$columnName, $comparisonOperator, $value];             
+                        $eloquentQuery[] = [$columnName, $comparisonOperator, $value];
                     } else {
                         return abort(400, "Operator '{$operator}' not allowed for parameter '{$param}'");
                     }
                 }
             } else {
-                if($param == 'page' || 'perPage') {
+                if ($param == 'page' || 'perPage') {
                     continue;
                 }
-                
+
                 return abort(400, "Parameter '{$param}' not allowed\n");
             }
         }
 
         return $eloquentQuery;
+    }
+
+    /**
+     * Translates orderBy fields to database columns with columnMap
+     *
+     * @param string $orderByField
+     * @param string $defaultColumn
+     * @param array $columnMap
+     * @return array
+     */
+    function translateOrderBy(?string $orderByField, string $defaultColumn, array $columnMap): array
+    {
+        $orderByColumn = $defaultColumn;
+        $orderByType = 'asc';
+
+        if (!empty($orderByField)) {
+            $orderByArray = explode(',', $orderByField);
+
+            if (count($orderByArray) != 2) {
+                abort(400, 'Invalid orderBy, too little/many parameters');
+            } else {
+                $orderByColumn = $orderByArray[0];
+                $orderByType = $orderByArray[1];
+
+                if (isset($columnMap[$orderByColumn])) {
+                    $orderByColumn = $columnMap[$orderByColumn];
+                }
+
+                if (!in_array($orderByColumn, $columnMap) || !in_array($orderByType, ['asc', 'desc'])) {
+                    abort(400, 'Invalid orderBy');
+                }
+            }
+        }
+
+        return [$orderByColumn, $orderByType];
     }
 }


### PR DESCRIPTION
Added the query parameter `?orderBy=<field>,<asc | desc>`. 
The field can be any field you get on the response, you can also order by dates.

OrderBy is available on the following endpoints : 
/commentaires
/favoris
/groupes
/piecesJointes
/relations
/reponsesCommentaire
/ressources
/utilisateurs